### PR TITLE
Fix conflict with other plugins patching the same method

### DIFF
--- a/lib/additionals/patches/formatting_helper_patch.rb
+++ b/lib/additionals/patches/formatting_helper_patch.rb
@@ -4,12 +4,15 @@ module Additionals
       extend ActiveSupport::Concern
 
       included do
-        prepend InstanceOverwriteMethods
+        include InstanceMethods
+        alias_method :heads_for_wiki_formatter_without_additionals, :heads_for_wiki_formatter
+        alias_method :heads_for_wiki_formatter, :heads_for_wiki_formatter_with_additionals
       end
 
-      module InstanceOverwriteMethods
-        def heads_for_wiki_formatter
-          super
+      module InstanceMethods
+        def heads_for_wiki_formatter_with_additionals
+          heads_for_wiki_formatter_without_additionals
+
           return if @additionals_macro_list
 
           @additionals_macro_list = AdditionalsMacro.all(filtered: Additionals.setting(:hidden_macros_in_toolbar).to_a,


### PR DESCRIPTION
Hi!

When installing this plugin, I noticed a conflict with an other plugin causing 500 errors on any page with a text area. According to redmine logs, an infinite recursive call occur between two patches trying to patch the `heads_for_wiki_formatter` method.

The conflicting patches in question:
* [AlphaNodes/additionals:/lib/additionals/patches/formatting_helper_patch.rb](https://github.com/AlphaNodes/additionals/blob/master/lib/additionals/patches/formatting_helper_patch.rb)
* [eXolnet/redmine_quick_replies:/lib/redmine_quick_replies/patches/wiki_formatting_patch.rb](https://github.com/eXolnet/redmine_quick_replies/blob/master/lib/redmine_quick_replies/patches/wiki_formatting_patch.rb)

This PR fix the way the `heads_for_wiki_formatter` method is patch, using the same way the `sidebar` method is patch (see [wiki_patch.rb](https://github.com/AlphaNodes/additionals/blob/master/lib/additionals/patches/wiki_patch.rb)).

I have tested this PR on our staging area and it does fix the issue. Let me know if you have any comments on the PR.

Thanks!