### PR TITLE
Update projects_controller_patch.rb

### DIFF
--- a/lib/additionals/patches/projects_controller_patch.rb
+++ b/lib/additionals/patches/projects_controller_patch.rb
@@ -39,11 +39,14 @@ module Additionals
             @dashboard = Dashboard.default DashboardContentProject::TYPE_NAME, @project
           end
 
-          @dashboard.content_project = @project
-          recently_used_dashboard_save @dashboard, @project
-          @can_edit = @dashboard&.editable?
-          @dashboard_sidebar = dashboard_sidebar? @dashboard, params
+          if @dashboard
+            @dashboard.content_project = @project
+            recently_used_dashboard_save @dashboard, @project
+            @can_edit = @dashboard.editable?
+            @dashboard_sidebar = dashboard_sidebar? @dashboard, params
+          end
         end
+        
       end
     end
   end


### PR DESCRIPTION
If `@dashboard` is not found, the code `@dashboard.content_project = @project` triggers an error.