### PR TITLE
Issues without assignee are not showing in the issue summary.

### DIFF
--- a/app/views/reports/_additionals_simple.html.slim
+++ b/app/views/reports/_additionals_simple.html.slim
@@ -1,7 +1,7 @@
 ruby:
   case field_name
   when 'assigned_to_id'
-    rows = Setting.issue_group_assignment? ? @project.visible_principals : @project.visible_users # rubocop:disable Lint/UselessAssignment
+    rows = Setting.issue_group_assignment? ? @project.visible_principals : @project.visible_users + [User.new(:firstname => "[#{l(:label_none)}]")] # rubocop:disable Lint/UselessAssignment
   when 'author_id'
     rows = @project.visible_users # rubocop:disable Lint/UselessAssignment
   end

--- a/lib/additionals/patches/reports_controller_patch.rb
+++ b/lib/additionals/patches/reports_controller_patch.rb
@@ -15,9 +15,9 @@ module Additionals
           return if @rows.nil?
 
           if Setting.issue_group_assignment? && params[:detail] == 'assigned_to'
-            @rows = @project.visible_principals
+            @rows = @project.visible_principals + [User.new(:firstname => "[#{l(:label_none)}]")]
           elsif %w[assigned_to author].include? params[:detail]
-            @rows = @project.visible_users
+            @rows = @project.visible_users + [User.new(:firstname => "[#{l(:label_none)}]")]
           end
         end
       end

--- a/test/functional/reports_controller_test.rb
+++ b/test/functional/reports_controller_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require File.expand_path '../../test_helper', __FILE__
+
+class ReportsControllerTest < Additionals::ControllerTest
+  fixtures :projects, :trackers, :issue_statuses, :issues,
+           :enumerations, :users, :issue_categories,
+           :projects_trackers,
+           :roles,
+           :member_roles,
+           :members,
+           :enabled_modules,
+           :versions
+
+  def test_get_issue_report_details_by_assignee_should_show_non_assigned_issue_count
+    Issue.delete_all
+    Issue.generate!
+    Issue.generate!
+    Issue.generate!(:status_id => 5)
+    Issue.generate!(:assigned_to_id => 2)
+
+    get(
+      :issue_report_details,
+      :params => {
+        :id => 1,
+        :detail => 'assigned_to'
+      }
+    )
+    assert_select 'table.list tbody :last-child' do
+      assert_select 'td', :text => "[#{I18n.t(:label_none)}]"
+      assert_select ':nth-child(2)', :text => '2' # status:1
+      assert_select ':nth-child(6)', :text => '1' # status:5
+      assert_select ':nth-child(8)', :text => '2' # open
+      assert_select ':nth-child(9)', :text => '1' # closed
+      assert_select ':nth-child(10)', :text => '3' # total
+    end
+  end
+end


### PR DESCRIPTION
In [r21309](https://www.redmine.org/projects/redmine/repository/revisions/21309) were added statistics about issues without assignee, version or category to the issue summary. Additionals overriding some code in reports_controllers which breaking that patch (mostly for Assignee).

Here is an example with applied PR:

![ksnip_20220601-130603](https://user-images.githubusercontent.com/49897128/171615107-7d1f8e8b-6806-461c-a45c-284602940f58.png)

Highlighted row not rendering at the current main branch.

Test was copied from redmine to make sure it is not broken in the future.