### PR TITLE
An error when trying to past emoji when using CommonMark

### DIFF
--- a/lib/additionals/wiki_formatting/common_mark/emoji_filter.rb
+++ b/lib/additionals/wiki_formatting/common_mark/emoji_filter.rb
@@ -45,7 +45,7 @@ module Additionals
         def emoji_unicode_element_unicode_filter(text)
           text.gsub emoji_unicode_pattern do |moji|
             emoji = TanukiEmoji.find_by_codepoints moji # rubocop: disable Rails/DynamicFindBy
-            emoji_tag_native emoji, name
+            emoji_tag_native emoji, moji
           end
         end
 


### PR DESCRIPTION
There is an error when trying to past text containing emoji and redmine formatter is a CommonMark Markdown.

I'm not sure if this is a typo but [patch](https://github.com/AlphaNodes/additionals/blob/aab4ed749a9b120fb3415a4d84b412689f4f6ba0/lib/additionals/wiki_formatting/common_mark/emoji_filter.rb#L48) doesn't work for CommonMark. It raises `undefined local variable or method 'name' `.

Tried on textile - works fine.