### PR TITLE
Wrong position of popup menu

### DIFF
--- a/assets/javascripts/additionals_macro_button.js
+++ b/assets/javascripts/additionals_macro_button.js
@@ -25,7 +25,7 @@ jsToolBar.prototype.macroMenu = function(fn){
   menu.menu().width(170).position({
     my: 'left top',
     at: 'left bottom',
-    of: this.toolNodes['precode']
+    of: this.toolNodes['macros']
   });
   $(document).on('mousedown', function() {
     menu.remove();


### PR DESCRIPTION
It should be aligned to the left edge of the Macro button.

![image](https://user-images.githubusercontent.com/779003/211805797-3e035089-e242-4dd0-9184-84808e14b302.png)
