### PR TITLE
fix(dashboard): fix ProjectSystemDefaultChangeException 

### DIFF
--- a/app/views/dashboards/_form.html.slim
+++ b/app/views/dashboards/_form.html.slim
@@ -12,7 +12,7 @@
       = hidden_field_tag 'dashboard[dashboard_type]', @dashboard.dashboard_type if @dashboard.new_record?
       - if @project
         = hidden_field_tag 'dashboard[content_project_id]', @project.id
-        - if @allowed_projects.present? && @allowed_projects.count > 1
+        - if @allowed_projects.present? && @allowed_projects.count > 0
           p
             = f.select :project_id,
                       project_tree_options_for_select(@allowed_projects,

--- a/app/views/dashboards/_form.html.slim
+++ b/app/views/dashboards/_form.html.slim
@@ -12,7 +12,7 @@
       = hidden_field_tag 'dashboard[dashboard_type]', @dashboard.dashboard_type if @dashboard.new_record?
       - if @project
         = hidden_field_tag 'dashboard[content_project_id]', @project.id
-        - if @allowed_projects.present? && @allowed_projects.count > 0
+        - if @allowed_projects.present? && @allowed_projects.count.positive?
           p
             = f.select :project_id,
                       project_tree_options_for_select(@allowed_projects,


### PR DESCRIPTION
This PR is to fix a ProjectSystemDefaultChangeException that occurs when allowed_projects.count equals 1.

If you update the default project dashboard, the following exception will occur:
```
Dashboard::ProjectSystemDefaultChangeException (Dashboard::ProjectSystemDefaultChangeException):

plugins/additionals/app/models/dashboard.rb:389:in 'validate_project_system_default'
plugins/additionals/app/controllers/dashboards_controller.rb:113:in 'update'
lib/redmine/sudo_mode.rb:61:in 'sudo_mode'
```