### PR TITLE
Fix argument parsing on meteoblue macro

### DIFF
--- a/lib/additionals/wiki_macros/meteoblue_macro.rb
+++ b/lib/additionals/wiki_macros/meteoblue_macro.rb
@@ -97,9 +97,9 @@ module Additionals
     end
   end
 
-  def self.meteoblue_flag(options, name, default = tue)
-    flag = "#{name}="
-    flag << if RedminePluginKit.true?(options[name]) || default
+  def self.meteoblue_flag(options, name, default = true)
+    flag = "&#{name}="
+    flag << if RedminePluginKit.true? options[name] || default
               '1'
             else
               '0'


### PR DESCRIPTION
The iframe URL was wrongly constructed without ampersands and meteoblue_flag values were not correctly parsed.

I've tested and confirmed that this change fixes the issue.