### PR TITLE
fix: use prepend instead of alias_method pattern

### DIFF
--- a/lib/additionals/patches/queries_helper_patch.rb
+++ b/lib/additionals/patches/queries_helper_patch.rb
@@ -6,23 +6,20 @@ module Additionals
       extend ActiveSupport::Concern
 
       included do
-        include InstanceMethods
-
-        alias_method :column_value_without_category_link, :column_value
-        alias_method :column_value, :column_value_with_category_link
+        prepend InstanceOverwriteMethods
       end
 
-      module InstanceMethods
+      module InstanceOverwriteMethods
         # Render the issue category column as a link to the issue list of the
         # issue's project, filtered by this category. Falls back to the core
         # rendering when link_to_issue_category is not available in the current
         # helper context. The helper itself returns the plain category name when
         # the issue_link_category setting is disabled.
-        def column_value_with_category_link(column, item, value)
+        def column_value(column, item, value)
           if column.name == :category && item.is_a?(Issue) && respond_to?(:link_to_issue_category)
             link_to_issue_category item, category: value
           else
-            column_value_without_category_link column, item, value
+            super
           end
         end
       end

--- a/lib/additionals/patches/query_patch.rb
+++ b/lib/additionals/patches/query_patch.rb
@@ -6,17 +6,10 @@ module Additionals
       extend ActiveSupport::Concern
 
       included do
+        prepend InstanceOverwriteMethods
         include InstanceMethods
 
         attr_accessor :search_string
-
-        # NOTE: alias_method instead of prepend to stay compatible with redmineup redmine_contacts
-        alias_method :add_available_filter_without_additionals, :add_available_filter
-        alias_method :add_available_filter, :add_available_filter_with_additionals
-
-        # NOTE: alias_method instead of prepend to stay compatible with redmineup redmine_contacts
-        alias_method :add_filter_without_additionals, :add_filter
-        alias_method :add_filter, :add_filter_with_additionals
 
         # list_optional is default, but required for short filters
         operators_by_filter_type[:author_optional] = operators_by_filter_type[:list_optional]
@@ -44,9 +37,9 @@ module Additionals
         end
       end
 
-      module InstanceMethods
-        def add_filter_with_additionals(field, operator, values = nil)
-          add_filter_without_additionals field, operator, values
+      module InstanceOverwriteMethods
+        def add_filter(field, operator, values = nil)
+          super
           return unless available_filters[field]
 
           initialize_user_values_for_select2 field, values
@@ -55,14 +48,16 @@ module Additionals
           true
         end
 
-        def add_available_filter_with_additionals(field, options)
-          add_available_filter_without_additionals field, options
+        def add_available_filter(field, options)
+          super
           values = filters&.dig(field, :values) || []
           initialize_user_values_for_select2 field, values
 
           @available_filters
         end
+      end
 
+      module InstanceMethods
         def ids_from_string(string)
           string.to_s.scan(/\d+/).map(&:to_i)
         end


### PR DESCRIPTION
When combining the additionals plugin with other plugins, e.g. the redmine_products plugin by RedmineUp, some pages like `/my/page` will crash with the following stack trace:

```
I, [2026-06-17T16:01:47.314842 #21255]  INFO -- : [97a23156-7a96-493a-b256-2a332adf5f9d] Started GET "/my/page" for 131.169.132.62 at 2026-06-17 16:01:47 +0000                                                                                                    
I, [2026-06-17T16:01:47.316080 #21255]  INFO -- : [97a23156-7a96-493a-b256-2a332adf5f9d] Processing by MyController#page as HTML                                                                                                                                   
I, [2026-06-17T16:01:47.323266 #21255]  INFO -- : [97a23156-7a96-493a-b256-2a332adf5f9d]   Current user: mhier (id=108)                                                                                                                                            
I, [2026-06-17T16:01:47.354849 #21255]  INFO -- : [97a23156-7a96-493a-b256-2a332adf5f9d]   Rendered layout layouts/base.html.erb (Duration: 17.6ms | GC: 1.6ms)                                                                                                    
I, [2026-06-17T16:01:47.355437 #21255]  INFO -- : [97a23156-7a96-493a-b256-2a332adf5f9d] Completed 500 Internal Server Error in 39ms (ActiveRecord: 6.2ms (9 queries, 0 cached) | GC: 2.1ms)                                                                       
F, [2026-06-17T16:01:47.406690 #21255] FATAL -- : [97a23156-7a96-493a-b256-2a332adf5f9d]                                                                                                                                                                           
[97a23156-7a96-493a-b256-2a332adf5f9d] SystemStackError (stack level too deep):                                                                                                                                                                                    
[97a23156-7a96-493a-b256-2a332adf5f9d]                                                                                                                                                                                                                             
[97a23156-7a96-493a-b256-2a332adf5f9d] plugins/redmine_products/lib/redmine_products/patches/query_patch.rb:14:in `add_filter'                                                                                                                                     
[97a23156-7a96-493a-b256-2a332adf5f9d] plugins/additionals/lib/additionals/patches/query_patch.rb:49:in `add_filter_with_additionals'                                                                                                                              
[97a23156-7a96-493a-b256-2a332adf5f9d] plugins/redmine_products/lib/redmine_products/patches/query_patch.rb:14:in `add_filter'                                                                                                                                     
[97a23156-7a96-493a-b256-2a332adf5f9d] plugins/additionals/lib/additionals/patches/query_patch.rb:49:in `add_filter_with_additionals' 
<<<countless repeats of these two lines>>>
[97a23156-7a96-493a-b256-2a332adf5f9d] app/helpers/my_helper.rb:98:in `render_issuesassignedtome_block'
[97a23156-7a96-493a-b256-2a332adf5f9d] app/helpers/my_helper.rb:64:in `render_block_content'
[97a23156-7a96-493a-b256-2a332adf5f9d] app/helpers/my_helper.rb:35:in `render_block'
[97a23156-7a96-493a-b256-2a332adf5f9d] app/helpers/my_helper.rb:27:in `block in render_blocks'
[97a23156-7a96-493a-b256-2a332adf5f9d] app/helpers/my_helper.rb:26:in `each'
[97a23156-7a96-493a-b256-2a332adf5f9d] app/helpers/my_helper.rb:26:in `render_blocks'
[97a23156-7a96-493a-b256-2a332adf5f9d] app/views/my/page.html.erb:14
[97a23156-7a96-493a-b256-2a332adf5f9d] app/views/my/page.html.erb:12:in `each'
[97a23156-7a96-493a-b256-2a332adf5f9d] app/views/my/page.html.erb:12
[97a23156-7a96-493a-b256-2a332adf5f9d] lib/redmine/sudo_mode.rb:78:in `sudo_mode'
```

This PR aims at fixing this, by changing the way how the plugin overrides methods to the modern `prepend`-based pattern instead of using the outdated `alias_method` pattern.

Note: I am not a ruby expert, so maybe I am doing it in the wrong way here. I apologise in that case.

Note2: This is a draft, because I am using a pre-release version of the redmine_products plugin. The current release also uses the old alias_method. Unfortunately, this is incompatible in both directions. I know, other plugins also move to the new `prepend`-based pattern, so this plugin should eventually do it as well, but maybe it is not the right timing yet?